### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "ferrosaur"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "darling",

--- a/crates/ferrosaur/CHANGELOG.md
+++ b/crates/ferrosaur/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1](https://github.com/tonywu6/ferrosaur/compare/ferrosaur-v0.1.0...ferrosaur-v0.1.1)
+
+### Other changes
+
+#### <!-- 3 --> Documentation
+
+- avoid layout shift due to badges [`b64b5b3`](https://github.com/tonywu6/ferrosaur/commit/b64b5b3faa1f9ee61cba4ad149dd589356681fb9)
+- reword README [`1134a63`](https://github.com/tonywu6/ferrosaur/commit/1134a63cf92e52d7c62607818505e1a24a0a9cc2)
+- adjust examples [`9eb54f5`](https://github.com/tonywu6/ferrosaur/commit/9eb54f5b91df013cb1e8c1c75bbde6fdbeb691ba)
+
 ## [0.1.0](https://github.com/tonywu6/ferrosaur/releases/tag/ferrosaur-v0.1.0) - 2025-05-07
 
 Initial release!

--- a/crates/ferrosaur/Cargo.toml
+++ b/crates/ferrosaur/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ferrosaur"
 publish = true
-version = "0.1.0"
+version = "0.1.1"
 
 edition.workspace = true
 


### PR DESCRIPTION



## 🤖 New release

* `ferrosaur`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/tonywu6/ferrosaur/compare/ferrosaur-v0.1.0...ferrosaur-v0.1.1)

### Other changes

#### <!-- 3 --> Documentation

- avoid layout shift due to badges [`b64b5b3`](https://github.com/tonywu6/ferrosaur/commit/b64b5b3faa1f9ee61cba4ad149dd589356681fb9)
- reword README [`1134a63`](https://github.com/tonywu6/ferrosaur/commit/1134a63cf92e52d7c62607818505e1a24a0a9cc2)
- adjust examples [`9eb54f5`](https://github.com/tonywu6/ferrosaur/commit/9eb54f5b91df013cb1e8c1c75bbde6fdbeb691ba)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).